### PR TITLE
Extended openapi.yaml, added README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,47 @@
-# [_TEMPLATE_]
+# Bundestag Lobbyregister API
 
-## Quickstart
+API des Deutschen Bundestags zum Lobbyregister für die Interessenvertretung gegenüber dem Deutschen Bundestag und der Bundesregierung.
 
-- Add openAPI spec inside _openapi.yml_
-- Update _index.html_ (insert the api-name in the title)
-- Update _generator_config.yaml_ (Update all values surrounded with <>)
-- Update the url in _CNAME_ once the api has its own subdomain
-- Replace this README
+
+## Registereinträge Detailprofile
+
+**URL:** https://www.lobbyregister.bundestag.de/sucheDetailJson
+	
+Die API zum Lobbyregister bietet Nutzer/-innen die Möglichkeit, die öffentlichen Daten zu Detailprofilen der registrierten Interessenvertreter/-innen im JSON Format herunterzuladen, potenziell gefiltert und sortiert u.a. auf Basis folgender GET-Parameter:
+
+
+**Parameter:** *q* (Optional)
+
+Query String: Enthält die angegebene Suchanfrage - einen Text, der in einem der Textfelder vorkommen muss. Wird der Parameter nicht gesetzt, werden alle Registereinträge ausgegeben.
+
+
+**Parameter:** *sort* (Optional)
+
+- "REGISTRATION_ASC"
+- "REGISTRATION_DESC"
+- "NAME_ASC"
+- "NAME_DESC"
+- "FINANCIALEXPENSES_ASC"
+- "FINANCIALEXPENSES_DESC"
+
+Sortierungs-Kriterium: 
+"REGISTRATION_ASC"=Sortierung nach Registernummer in aufsteigender Reihenfolge; 
+"REGISTRATION_DESC"=Sortierung nach Registernummer in absteigender Reihenfolge; 
+"NAME_ASC"=Sortierung nach Name in aufsteigender Reihenfolge; 
+"NAME_DESC"=Sortierung nach Name in absteigender Reihenfolge; 
+"FINANCIALEXPENSES_DESC"=Sortierung nach Höhe der finanziellen Aufwendungen in aufsteigender Reihenfolge (beginnend mit Einträgen ohne Angabe); 
+"FINANCIALEXPENSES_DESC"=Sortierung nach Höhe der finanziellen Aufwendungen in absteigender Reihenfolge; 
+Wird der Parameter nicht gesetzt wird die erste Option als Kriterium herangezogen.
+
+
+### Alternative Zugänge
+
+Eine Vorschau der o.g. Ergebnisse lässt sich unter Verwendung der o.g. GET-Parameter von https://www.lobbyregister.bundestag.de/sucheJson beziehen. 
+Die Ergebnisse zu einzelnen Registereinträgen lassen sich wiederum über die Pfad-Parameter Registernummer *registerNumber* und Interessenvertreter/-innen-ID *registerEntryDetail-id* auch gezielt von https://www.lobbyregister.bundestag.de/suche/{registerNumber}/{registerEntryDetail-id} beziehen.
+
+
+## Beispiel
+
+```bash
+interessenvertretungen=$(curl -m 60 'https://www.lobbyregister.bundestag.de/sucheDetailJson?q=Security&sort=FINANCIALEXPENSES_DESC')
+```

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.51.1/swagger-ui.min.css">
-    <title>{{repo_name}} - OpenAPI Documentation</title>
+    <title>Bundestag Lobbyregister API - OpenAPI Documentation</title>
 
 <body>
     <div id="openapi">

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: '3.0.2'
 info:
-  title: "Bundestag: Lobbyregister"
+  title: "Bundestag: Lobbyregister API"
   version: '1.3' # According to the latest newsletter
 
 servers:
@@ -33,12 +33,14 @@ components:
   schemas:
     SortOrder:
       type: string
+      description: "Sorting criterion"
       example: "REGISTRATION_DESC"
       enum:
-      - "REGISTRATION_DESC"
       - "REGISTRATION_ASC"
+      - "REGISTRATION_DESC"
       - "NAME_ASC"
       - "NAME_DESC"
+      - "FINANCIALEXPENSES_ASC"
       - "FINANCIALEXPENSES_DESC"
 
     DetailedSearchResults:


### PR DESCRIPTION
I added a missing enum-entry (FINANCIALEXPENSES_ASC) and a description to the documentation of the sort-parameter; added a REAME.md based on the content of openapi.yaml and fixed the API-name in index.html.